### PR TITLE
make personal access token a requirement for two APIs with auth

### DIFF
--- a/pkg/swagger-ui/swagger.json
+++ b/pkg/swagger-ui/swagger.json
@@ -132,9 +132,10 @@
           {
             "type": "string",
             "x-go-name": "Personal Access Token",
-            "description": "For authorization in case you get wrong branch does not exist or 4xx/5xx errors",
+            "description": "For authorization",
             "name": "personalAccessToken",
-            "in": "query"
+            "in": "query",
+            "required": true
           }
         ],
         "responses": {
@@ -266,9 +267,10 @@
           {
             "type": "string",
             "x-go-name": "Personal Access Token",
-            "description": "For authorization in case you get wrong branch does not exist or 4xx/5xx errors",
+            "description": "For authorization",
             "name": "personalAccessToken",
-            "in": "query"
+            "in": "query",
+            "required": true
           }
         ],
         "responses": {


### PR DESCRIPTION
## Description
- This is required in order to get correct response from GitHub REST APIs
- Currently, empty personal access token is being sent which does not fetch right response

## How did you test the changes?
Tested locally

## Testing Screenshots (Optional)
<img width="1440" alt="image" src="https://github.com/nyuoss/git-service/assets/83601608/2bc13a47-163f-4939-b93b-088a80fb25c8">

<img width="1440" alt="image" src="https://github.com/nyuoss/git-service/assets/83601608/5cecd02e-f373-454d-973b-3c3a48eb8642">
